### PR TITLE
Made copying of the config file less ambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ I am currently developing this under ZFS on Linux in Ubuntu, but all varients of
 
 **Installation**
 
-You can either use a *.wbm.gz from the releases tab, or "# git clone https://github.com/jonmatifa/zfsmanager.git" from the webmin root directory (Centos/REHL: /usr/libexec/webmin, Debian/Ubuntu: /usr/share/webmin), this will clone everything into the zfsmanager subfolder (which will be created). Then copy the "config" file to /etc/webmin/zfsmanager once that is done, you can then keep up to date with by "# git pull" from the webmin/zfsmanager directory.
+You can either use a *.wbm.gz from the releases tab, or "# git clone https://github.com/jonmatifa/zfsmanager.git" from the webmin root directory (Centos/REHL: /usr/libexec/webmin, Debian/Ubuntu: /usr/share/webmin), this will clone everything into the zfsmanager subfolder (which will be created). Then copy the "config" file to /etc/webmin/zfsmanager/config once that is done, you can then keep up to date with by "# git pull" from the webmin/zfsmanager directory.
 
 **Feedback**
 


### PR DESCRIPTION
It took me a few minutes to realize that the config file should be copied to the zfsmanager folder in /etc/webmin rather than as a file called zfsmanager in /etc/webmin. So I propose this small change to make installation less ambiguous.